### PR TITLE
Change virtuoso docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - virtuoso
   virtuoso:
-    image: "tenforce/virtuoso"
+    image: "nlesc/virtuoso"
     restart: unless-stopped
     # ports:
     #   - "8890:8890"


### PR DESCRIPTION
We have to build the Virtuoso docker image by ourselves on the latest source code of https://github.com/openlink/virtuoso-opensource.

The docker file ([here](https://github.com/fair-data/docker-virtuoso)) is forked from that of the docker image `tenforce/virtuoso` we previously used.

The openlink also releases docker image on its latest source code ([here](https://hub.docker.com/r/openlink/virtuoso-opensource-7)), but the image does not meet our needs. It does not expose an environment variable to easily set SPARQL UPDATE access.